### PR TITLE
Fix: N1N2 Message Transfer failure after N2 Handover

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -3131,6 +3131,15 @@ func HandleHandoverNotify(ran *context.AmfRan, message *ngapType.NGAPPDU) {
 			ngapType.CauseNasPresentNormalRelease)
 	}
 
+	// Setting target UE ongoing procedure to nothing after N2 Handover is finished - By CDAC TVM
+	if amfUe.GetOnGoing(amfUe.GetAnType()).Procedure == context.OnGoingProcedureN2Handover {
+		targetUe.Log.Infof("Setting target UE on going procedure to nothing after N2 Handover")
+		amfUe.SetOnGoing(amfUe.GetAnType(), &context.OnGoingProcedureWithPrio{
+			Procedure: context.OnGoingProcedureNothing,
+		})
+	}
+	// End of modification - By CDAC TVM
+
 	// TODO: The UE initiates Mobility Registration Update procedure as described in clause 4.2.2.2.2.
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR fixes N1N2 Message Transfer failure after N2 handover issue. After N2 Handover(Handover Notify), UE ongoing procedure is set as nothing. This will ensure that the N1N2 transfer proper working.

**Which issue(s) this PR fixes**:
Fixes #48 

**Test Report Added?**:
> /kind TESTED

**Test Report**:
[AMF log](https://github.com/user-attachments/files/18272349/amf-19dec-N2HO.log)
[SMF log](https://github.com/user-attachments/files/18272348/smf-19dec.log)

**Special notes for your reviewer**:
Nil