### PR TITLE
Fix: N2 message after N2 Handover goes to source RAN instead of target RAN

### DIFF
--- a/ngap/handler.go
+++ b/ngap/handler.go
@@ -1266,7 +1266,13 @@ func HandleUEContextReleaseComplete(ran *context.AmfRan, message *ngapType.NGAPP
 		// TODO: it's a workaround, need to fix it.
 		targetRanUe := context.AMF_Self().RanUeFindByAmfUeNgapID(ranUe.TargetUe.AmfUeNgapId)
 
-		targetRanUe.Ran = ran
+		// If target UE RAN is nil, set it to current RAN - By CDAC TVM
+		if targetRanUe.Ran == nil {
+			ran.Log.Warnf("targetRanUe RAN is nil - Setting current RAN for target UE with AmfUeNgapId: %v", ranUe.TargetUe.AmfUeNgapId)
+			targetRanUe.Ran = ran
+		}
+		// End of modification - By CDAC TVM
+
 		context.DetachSourceUeTargetUe(ranUe)
 		err := ranUe.Remove()
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
Before this PR, after an N2 Handover, the N1N2 message erroneously sent N2 messages such as PDU Session Resource Setup Request or Initial Context Setup Request to the source node instead of the target node.
This fix ensures that the N2 message is sent to the target RAN since the UE is already released from the source RAN.

**Which issue(s) this PR fixes**:
Fixes #50 

**Test Report Added?**:
> /kind TESTED

**Test Report**:
[Logs & PCAPs](https://github.com/user-attachments/files/18272529/Fix-N2-After-HO.zip)

**Special notes for your reviewer**:
Nil