### PR TITLE
Fix: N1N2 failure after N2 Handover since UE AMBR values are nil

### DIFF
--- a/ngap/message/build.go
+++ b/ngap/message/build.go
@@ -767,8 +767,24 @@ func BuildPDUSessionResourceSetupRequest(ue *context.RanUe, nasPdu []byte,
 	ie.Criticality.Value = ngapType.CriticalityPresentIgnore
 	ie.Value.Present = ngapType.PDUSessionResourceSetupRequestIEsPresentUEAggregateMaximumBitRate
 	ie.Value.UEAggregateMaximumBitRate = new(ngapType.UEAggregateMaximumBitRate)
-	ueAmbrUL := ngapConvert.UEAmbrToInt64(ue.AmfUe.AccessAndMobilitySubscriptionData.SubscribedUeAmbr.Uplink)
-	ueAmbrDL := ngapConvert.UEAmbrToInt64(ue.AmfUe.AccessAndMobilitySubscriptionData.SubscribedUeAmbr.Downlink)
+
+	// ueAmbrUL := ngapConvert.UEAmbrToInt64(ue.AmfUe.AccessAndMobilitySubscriptionData.SubscribedUeAmbr.Uplink)
+	// ueAmbrDL := ngapConvert.UEAmbrToInt64(ue.AmfUe.AccessAndMobilitySubscriptionData.SubscribedUeAmbr.Downlink)
+
+	// ueAmbrUL & ueAmbrDL is set to default value of 1000000000 if it's nil - By CDAC TVM
+	var ueAmbrUL, ueAmbrDL int64
+	if ue.AmfUe == nil || ue.AmfUe.AccessAndMobilitySubscriptionData == nil || ue.AmfUe.AccessAndMobilitySubscriptionData.SubscribedUeAmbr == nil {
+		logger.NgapLog.Warn("Subscribed UE AMBR is nil; using default AMBR values (1000000000 UL, 1000000000 DL)")
+		ueAmbrUL, ueAmbrDL = 1000000000, 1000000000
+	} else {
+		uplink := ue.AmfUe.AccessAndMobilitySubscriptionData.SubscribedUeAmbr.Uplink
+		downlink := ue.AmfUe.AccessAndMobilitySubscriptionData.SubscribedUeAmbr.Downlink
+
+		ueAmbrUL = ngapConvert.UEAmbrToInt64(uplink)
+		ueAmbrDL = ngapConvert.UEAmbrToInt64(downlink)
+	}
+	// End of modification - By CDAC TVM
+
 	ie.Value.UEAggregateMaximumBitRate.UEAggregateMaximumBitRateUL.Value = ueAmbrUL
 	ie.Value.UEAggregateMaximumBitRate.UEAggregateMaximumBitRateDL.Value = ueAmbrDL
 	pDUSessionResourceSetupRequestIEs.List = append(pDUSessionResourceSetupRequestIEs.List, ie)


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR sets the ueAmbrUL and ueAmbrDL to default value of 1000000000 if it's nil.

**Which issue(s) this PR fixes**:
Fixes #52 

**Test Report Added?**:
> /kind TESTED

**Test Report**:
[Logs & PCAPs](https://github.com/user-attachments/files/18272529/Fix-N2-After-HO.zip)

**Special notes for your reviewer**:
Nil
