### PR TITLE
Feat: Multiple Slice Support

### DIFF
--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -575,10 +575,8 @@ func (ue *AmfUe) InSubscribedNssai(targetSNssai *models.Snssai) bool {
 	for _, sNssai := range ue.SubscribedNssai {
 		logger.ContextLog.Info("sst:", sNssai.SubscribedSnssai.Sst, ", sd:", sNssai.SubscribedSnssai.Sd, "in core")
 		logger.ContextLog.Info("sst:", targetSNssai.Sst, ", sd:", targetSNssai.Sd, "from gNB")
-		if reflect.DeepEqual(*sNssai.SubscribedSnssai, targetSNssai) {
-			return true
-		} else if sNssai.SubscribedSnssai.Sst == targetSNssai.Sst {
-			targetSNssai.Sd = sNssai.SubscribedSnssai.Sd
+		if sNssai.SubscribedSnssai.Sst == targetSNssai.Sst &&
+			sNssai.SubscribedSnssai.Sd == targetSNssai.Sd {
 			return true
 		}
 	}

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -581,7 +581,6 @@ func (ue *AmfUe) InSubscribedNssai(targetSNssai *models.Snssai) bool {
 		} else if sNssai.SubscribedSnssai.Sst == targetSNssai.Sst && targetSNssai.Sd == "" {
 			targetSNssai.Sd = sNssai.SubscribedSnssai.Sd
 			return true
-
 		}
 	}
 	return false

--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -578,6 +578,10 @@ func (ue *AmfUe) InSubscribedNssai(targetSNssai *models.Snssai) bool {
 		if sNssai.SubscribedSnssai.Sst == targetSNssai.Sst &&
 			sNssai.SubscribedSnssai.Sd == targetSNssai.Sd {
 			return true
+		} else if sNssai.SubscribedSnssai.Sst == targetSNssai.Sst && targetSNssai.Sd == "" {
+			targetSNssai.Sd = sNssai.SubscribedSnssai.Sd
+			return true
+
 		}
 	}
 	return false

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1225,7 +1225,6 @@ func getSubscribedNssai(ue *context.AmfUe) {
 // TS 23.502 4.2.2.2.3 Registration with AMF Re-allocation
 func handleRequestedNssai(ue *context.AmfUe, anType models.AccessType) error {
 	amfSelf := context.AMF_Self()
-	disableSliceSelection := true
 
 	if ue.RegistrationRequest.RequestedNSSAI != nil {
 		requestedNssai, err := nasConvert.RequestedNssaiToModels(ue.RegistrationRequest.RequestedNSSAI)
@@ -1236,6 +1235,7 @@ func handleRequestedNssai(ue *context.AmfUe, anType models.AccessType) error {
 		ue.GmmLog.Infof("RequestedNssai: %+v", requestedNssai)
 
 		needSliceSelection := false
+		disableSliceSelection := false
 		for _, requestedSnssai := range requestedNssai {
 			ue.GmmLog.Debug("reg req Sst: ", requestedSnssai.ServingSnssai.Sst)
 			ue.GmmLog.Debug("reg req Sd: ", requestedSnssai.ServingSnssai.Sd)
@@ -1251,11 +1251,7 @@ func handleRequestedNssai(ue *context.AmfUe, anType models.AccessType) error {
 				ue.GmmLog.Debug("allowedSnssai: ", allowedSnssai)
 				ue.GmmLog.Info("slices are identical")
 				disableSliceSelection = true
-				break
-			} else {
-				ue.GmmLog.Info("slices are not identical")
-				disableSliceSelection = false
-				// needSliceSelection = true
+				continue
 			}
 		}
 		if !disableSliceSelection {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind new feature

**What this PR does / why we need it**:
This PR adds support for a single UE registering and operating with multiple network slices (S-NSSAIs).
Previously, UE registration and PDU session handling worked only with a single slice.
With this update:

AMF correctly retrieves, stores, and processes multiple subscribed & allowed NSSAIs from UDM/UDR.

Handling of AllowedNssai during UL NAS Transport is updated to ensure correct slice selection.

Multi-slice UE configurations are now supported for registration and PDU session establishment.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #91

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
