### PR TITLE
feat: implement Rejected NSSAI support in Registration Accept

### DIFF
--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -181,12 +181,13 @@ type AmfUe struct {
 	RegistrationArea map[models.AccessType][]models.Tai `json:"registrationArea,omitempty"`
 	LadnInfo         []LADN                             `json:"ladnInfo,omitempty"`
 	/* Network Slicing related context and Nssf */
-	NssfId                            string                                       `json:"nssfId,omitempty"`
-	NssfUri                           string                                       `json:"nssfUri,omitempty"`
-	NetworkSliceInfo                  *models.AuthorizedNetworkSliceInfo           `json:"networkSliceInfo,omitempty"`
-	AllowedNssai                      map[models.AccessType][]models.AllowedSnssai `json:"allowedNssai,omitempty"`
-	ConfiguredNssai                   []models.ConfiguredSnssai                    `json:"configuredNssai,omitempty"`
-	NetworkSlicingSubscriptionChanged bool                                         `json:"networkSlicingSubscriptionChanged,omitempty"`
+	NssfId                            string                                        `json:"nssfId,omitempty"`
+	NssfUri                           string                                        `json:"nssfUri,omitempty"`
+	NetworkSliceInfo                  *models.AuthorizedNetworkSliceInfo            `json:"networkSliceInfo,omitempty"`
+	AllowedNssai                      map[models.AccessType][]models.AllowedSnssai  `json:"allowedNssai,omitempty"`
+	RejectedNssai                     map[models.AccessType][]models.RejectedSnssai `json:"rejectedNssai,omitempty"` // Store slices rejected during registration to inform the UE
+	ConfiguredNssai                   []models.ConfiguredSnssai                     `json:"configuredNssai,omitempty"`
+	NetworkSlicingSubscriptionChanged bool                                          `json:"networkSlicingSubscriptionChanged,omitempty"`
 	/* T3513(Paging) */
 	T3513 *Timer `json:"t3513Value,omitempty"` // for paging
 	/* T3565(Notification) */
@@ -459,6 +460,7 @@ func (ue *AmfUe) init() {
 	ue.RanUe = make(map[models.AccessType]*RanUe)
 	ue.RegistrationArea = make(map[models.AccessType][]models.Tai)
 	ue.AllowedNssai = make(map[models.AccessType][]models.AllowedSnssai)
+	ue.RejectedNssai = make(map[models.AccessType][]models.RejectedSnssai) // Initialize the map for Rejected Slices to prevent nil pointer errors
 	ue.N1N2MessageIDGenerator = idgenerator.NewGenerator(1, 2147483647)
 	ue.N1N2MessageSubscribeIDGenerator = idgenerator.NewGenerator(1, 2147483647)
 	ue.OnGoing = make(map[models.AccessType]*OnGoingProcedureWithPrio)

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -817,6 +817,9 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ue *context.AmfUe, anType mod
 	if len(ue.Pei) == 0 {
 		gmm_message.SendIdentityRequest(ue.RanUe[anType], nasMessage.MobileIdentity5GSTypeImei)
 		return nil
+	} else {
+		// Log If it pass the check
+		ue.GmmLog.Infof("DEBUG CHECK: PEI is present. Proceeding with flow for SUPI: %s", ue.Supi)
 	}
 
 	// TODO (step 12 optional): the new AMF initiates ME identity check by invoking the
@@ -1225,6 +1228,11 @@ func getSubscribedNssai(ue *context.AmfUe) {
 // TS 23.502 4.2.2.2.3 Registration with AMF Re-allocation
 func handleRequestedNssai(ue *context.AmfUe, anType models.AccessType) error {
 	amfSelf := context.AMF_Self()
+	// 1. Initialize the rejected list for this access type to avoid stale data
+	if ue.RejectedNssai == nil {
+		ue.RejectedNssai = make(map[models.AccessType][]models.RejectedSnssai)
+	}
+	ue.RejectedNssai[anType] = []models.RejectedSnssai{}
 
 	if ue.RegistrationRequest.RequestedNSSAI != nil {
 		requestedNssai, err := nasConvert.RequestedNssaiToModels(ue.RegistrationRequest.RequestedNSSAI)
@@ -1252,6 +1260,18 @@ func handleRequestedNssai(ue *context.AmfUe, anType models.AccessType) error {
 				ue.GmmLog.Info("slices are identical")
 				disableSliceSelection = true
 				continue
+			} else {
+				// If slice is not in subscription, add to Rejected list with a specific Cause Code
+				rejectedItem := models.RejectedSnssai{
+					RejectedSnssai: &models.Snssai{
+						Sst: requestedSnssai.ServingSnssai.Sst,
+						Sd:  requestedSnssai.ServingSnssai.Sd,
+					},
+					RejectCause: models.RejectCause_S_NSSAI_NOT_AVAILABLE_IN_CURRENT_PLMN_OR_SNPN,
+				}
+
+				ue.RejectedNssai[anType] = append(ue.RejectedNssai[anType], rejectedItem)
+				ue.GmmLog.Warnf("S-NSSAI %v rejected: Not in subscription", requestedSnssai.ServingSnssai)
 			}
 		}
 		if !disableSliceSelection {

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -819,7 +819,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ue *context.AmfUe, anType mod
 		return nil
 	} else {
 		// Log If it pass the check
-		ue.GmmLog.Infof("DEBUG CHECK: PEI is present. Proceeding with flow for SUPI: %s", ue.Supi)
+		ue.GmmLog.Debugf("PEI is present. Proceeding with flow for SUPI: %s", ue.Supi)
 	}
 
 	// TODO (step 12 optional): the new AMF initiates ME identity check by invoking the

--- a/gmm/message/build.go
+++ b/gmm/message/build.go
@@ -518,6 +518,59 @@ func BuildRegistrationAccept(
 		registrationAccept.AllowedNSSAI.SetLen(uint8(len(buf)))
 		registrationAccept.AllowedNSSAI.SetSNSSAIValue(buf)
 	}
+
+	// Check for rejected slices and encode them into the Registration Accept message
+	// --- Rejected NSSAI Logic ---
+	if len(ue.RejectedNssai[anType]) > 0 {
+		registrationAccept.RejectedNSSAI = nasType.NewRejectedNSSAI(nasMessage.RegistrationAcceptRejectedNSSAIType)
+		var buf []uint8
+
+		for i, item := range ue.RejectedNssai[anType] {
+			// Convert S-NSSAI to NAS format
+			rawBytes := nasConvert.SnssaiToNas(*item.RejectedSnssai)
+
+			// Validate the raw bytes
+			if len(rawBytes) < 2 {
+				ue.GmmLog.Errorf("Rejected Item [%d] Invalid raw bytes length %d, skipping", i, len(rawBytes))
+				continue
+			}
+
+			// Prepare S-NSSAI content (strip the length byte)
+			var snssaiContent []byte
+			if len(rawBytes) > 1 {
+				snssaiContent = rawBytes[1:] // SST and optional SD
+			} else {
+				continue
+			}
+
+			// Map reject cause to NAS cause value
+			var cause uint8
+			switch item.RejectCause {
+			case models.RejectCause_S_NSSAI_NOT_AVAILABLE_IN_TA:
+				cause = 0x01
+			case models.RejectCause_S_NSSAI_NOT_AVAILABLE_DUE_TO_FAILED_OR_REVOKED_NSAA:
+				cause = 0x02
+			case models.RejectCause_S_NSSAI_NOT_AVAILABLE_IN_CURRENT_PLMN_OR_SNPN:
+				cause = 0x00
+			default:
+				cause = 0x00 // Default fallback
+			}
+
+			// Bits 8-5: Length of rejected S-NSSAI
+			// Bits 4-1: Cause value
+			contentLength := uint8(len(snssaiContent)) & 0x0F
+			causeNibble := cause & 0x0F
+			headerByte := (contentLength << 4) | causeNibble
+
+			// Append to buffer
+			buf = append(buf, headerByte)
+			buf = append(buf, snssaiContent...)
+		}
+
+		// Set final length and contents
+		registrationAccept.RejectedNSSAI.SetLen(uint8(len(buf)))
+		registrationAccept.SetRejectedNSSAIContents(buf)
+	}
 	/* TODO: DT-Trial: Commented below code because UE is not allowing rejected Nssais */
 	/*
 		if ue.NetworkSliceInfo != nil {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 
 require (
 	github.com/5GC-DEV/nas-cdac v0.0.0-20251003065343-87d9d21b06f6
-	github.com/5GC-DEV/openapi-cdac v1.0.1-0.20251124131326-494f05f365c8
+	github.com/5GC-DEV/openapi-cdac v1.0.1-0.20260109140746-44d5650a6474
 	github.com/5GC-DEV/util-cdac v0.0.0-20250930103432-58951725c085
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,11 @@ github.com/5GC-DEV/ngap-cdac v0.0.0-20251211063814-37e26c700d90 h1:xZLknQ5SWp1mi
 github.com/5GC-DEV/ngap-cdac v0.0.0-20251211063814-37e26c700d90/go.mod h1:f8IDKdSzArBRybHVqiz611IFFkZJT9A5HwAlzktNAQw=
 github.com/5GC-DEV/ngap-cdac v0.0.0-20251211084619-a3518c35bc31 h1:EQu1JPd1A7x5xQNw53wXTE5slWvCE3cttWFyqMMm4EQ=
 github.com/5GC-DEV/ngap-cdac v0.0.0-20251211084619-a3518c35bc31/go.mod h1:0RoJ2GgMzm+tqwCasiGq9FmD6mhTG6uznEB24VzneuA=
+github.com/5GC-DEV/openapi-cdac v1.0.0/go.mod h1:TFxV/NlwA7waEk3BqH6baTQ8oWpPMRDFC1YCEpPjl04=
 github.com/5GC-DEV/openapi-cdac v1.0.1-0.20251124131326-494f05f365c8 h1:QXEkID4P7RbR1YIkmiiUuIdFc9UagBIYedLHIN4xZGc=
 github.com/5GC-DEV/openapi-cdac v1.0.1-0.20251124131326-494f05f365c8/go.mod h1:KLX5UeLe67E9SQC/vVNArCa4KK4luoDNAS0kRGkdE74=
+github.com/5GC-DEV/openapi-cdac v1.0.1-0.20260109140746-44d5650a6474 h1:yMQLrfkqyLoEqkPamq0suv/64d+ovFuU2EmSAhLPJ9Y=
+github.com/5GC-DEV/openapi-cdac v1.0.1-0.20260109140746-44d5650a6474/go.mod h1:KLX5UeLe67E9SQC/vVNArCa4KK4luoDNAS0kRGkdE74=
 github.com/5GC-DEV/util-cdac v0.0.0-20250930103432-58951725c085 h1:KLL6S+ytEGgr3dX0sg6xDQ2TXZMtVt9TboPcu1j2nes=
 github.com/5GC-DEV/util-cdac v0.0.0-20250930103432-58951725c085/go.mod h1:IHTEJn2S2C/SDlKxFkgXbepYFhgxSTm7uhbxHOF42xQ=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind new feature

**What this PR does / why we need it**:
This PR implements the logic to handle and encode Rejected NSSAI during the UE Initial Registration procedure.

To comply with 3GPP Spec. Without this, the UE is unaware why specific network slices were not allowed and may attempt to re-request them unnecessarily. This feature ensures the AMF explicitly informs the UE about rejected slices and the specific reason for rejection.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#103](https://github.com/5GC-DEV/amf-cdac/issues/103)

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NIL

**Special notes for your reviewer**:
