### PR TITLE
Fix : AMF sends in-valid GUTI in registration accept

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -497,6 +497,9 @@ func HandleRegistrationRequest(ue *context.AmfUe, anType models.AccessType, proc
 			ue.Guti = guti
 			ue.ServingAmfChanged = false
 		} else {
+			if ue.Guti != "" {
+				ue.GmmLog.Debugf("Allocated GUTI: ", ue.Guti)
+			}
 			ue.GmmLog.Debugf("Serving AMF has changed but 5G-Core is not supporting for now")
 			ue.ServingAmfChanged = false
 		}

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -338,8 +338,12 @@ func forward5GSMMessageToSMF(
 	} else if errResponse != nil {
 		errJSON := errResponse.JsonData
 		n1Msg := errResponse.BinaryDataN1SmMessage
-		ue.GmmLog.Warnf("PDU Session Modification Procedure is rejected by SMF[pduSessionId:%d], Error[%s]",
-			pduSessionID, errJSON.Error.Cause)
+		if errJSON != nil && errJSON.Error != nil {
+			ue.GmmLog.Warnf("PDU Session Modification Procedure is rejected by SMF[pduSessionId:%d], Error[%s]",
+				pduSessionID, errJSON.Error.Cause)
+		} else {
+			ue.GmmLog.Errorf("recieved json error as nil from SMF")
+		}
 		if n1Msg != nil {
 			gmm_message.SendDLNASTransport(ue.RanUe[accessType], nasMessage.PayloadContainerTypeN1SMInfo,
 				errResponse.BinaryDataN1SmMessage, pduSessionID, 0, nil, 0)

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -497,8 +497,9 @@ func HandleRegistrationRequest(ue *context.AmfUe, anType models.AccessType, proc
 			ue.Guti = guti
 			ue.ServingAmfChanged = false
 		} else {
+			ue.GmmLog.Warnf("Invalid GUAMI received from UE")
 			if ue.Guti != "" {
-				ue.GmmLog.Debugf("Allocated GUTI: ", ue.Guti)
+				ue.GmmLog.Debugf("Proceeding with core allocated GUTI: ", ue.Guti)
 			}
 			ue.GmmLog.Debugf("Serving AMF has changed but 5G-Core is not supporting for now")
 			ue.ServingAmfChanged = false

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -486,11 +486,11 @@ func HandleRegistrationRequest(ue *context.AmfUe, anType models.AccessType, proc
 	case nasMessage.MobileIdentity5GSType5gGuti:
 		guamiFromUeGutiTmp, guti := nasConvert.GutiToString(mobileIdentity5GSContents)
 		guamiFromUeGuti = guamiFromUeGutiTmp
-		ue.Guti = guti
 		ue.GmmLog.Debugf("GUTI: %s", guti)
 
 		servedGuami := amfSelf.ServedGuamiList[0]
 		if reflect.DeepEqual(guamiFromUeGuti, servedGuami) {
+			ue.Guti = guti
 			ue.ServingAmfChanged = false
 		} else {
 			ue.GmmLog.Debugf("Serving AMF has changed but 5G-Core is not supporting for now")

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -342,7 +342,7 @@ func forward5GSMMessageToSMF(
 			ue.GmmLog.Warnf("PDU Session Modification Procedure is rejected by SMF[pduSessionId:%d], Error[%s]",
 				pduSessionID, errJSON.Error.Cause)
 		} else {
-			ue.GmmLog.Errorf("recieved json error as nil from SMF")
+			ue.GmmLog.Errorf("received json error as nil from SMF")
 		}
 		if n1Msg != nil {
 			gmm_message.SendDLNASTransport(ue.RanUe[accessType], nasMessage.PayloadContainerTypeN1SMInfo,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:

UE sends an in-valid GUTI in initial UE message [obtained from a different core]. The AMF responds correctly with identity request, for which UE sends the SUPI, Then it proceeds to Authentication request and Security Mode command. Following which the AMF sends an invalid GUTI to UE in Registration Accept.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #109

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
